### PR TITLE
fix: Preserve vncserver@.service Structure

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,19 +17,11 @@
     src: /usr/lib/systemd/system/vncserver@.service
   become: true
 
-- name: Configure ExecStart
-  lineinfile:
-    line: ExecStart=/usr/sbin/runuser -l {{ user }} -c "/usr/bin/vncserver %i"
+- name: Configure Service for {{ user }}
+  replace:
     path: /etc/systemd/system/vncserver-{{ user }}@.service
-    regexp: ^ExecStart=
-  become: true
-  notify: Restart VNC service
-
-- name: Configure PIDFile
-  lineinfile:
-    line: PIDFile=/home/{{ user }}/.vnc/%H%i.pid
-    path: /etc/systemd/system/vncserver-{{ user }}@.service
-    regexp: ^PIDFile=
+    regexp:  '<USER>'
+    replace: '{{ user }}'
   become: true
   notify: Restart VNC service
 


### PR DESCRIPTION
Replace <USER> with {{user}} instead of writing hard-coded entries into the service file.
The installed vncserver@.service template file was probably updated after 'recent' SystemD updates precipitated the need for changes.

This was discovered when the role added a PIDFile entry into the Install section at the end of the file, since the template no longer contains a PIDFile entry.  I first attempted to fix the problem PIDFile by adding an insertafter='^ExecStart=', but that resulted in other errors.  I subsequently realized the ExceStart line in the template vncserver@.service file had also been changed to call vncserver_wrapper.  Hence, the ultimate change made to resolve the errors.